### PR TITLE
feat: Update color scheme to peach and black

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -7,10 +7,10 @@
   --color-light-gray: #f5f5f5;
   --color-medium-gray: #888888;
   --color-dark-gray: #333333;
-  --color-black: #000000;
+  --color-black: #1C1C1C;
   
   /* Accent Color */
-  --color-accent-red: #dc2626;
+  --color-accent-peach: #FFDAB9;
   
   /* Semantic Colors */
   --color-background: var(--color-white);
@@ -19,7 +19,7 @@
   --color-text-secondary: var(--color-dark-gray);
   --color-text-muted: var(--color-medium-gray);
   --color-border: var(--color-medium-gray);
-  --color-accent: var(--color-accent-red);
+  --color-accent: var(--color-accent-peach);
   
   /* Typography */
   --font-heading-primary: 'Oswald', sans-serif;
@@ -37,13 +37,13 @@
 /* Dark Mode Theme */
 [data-theme="dark"] {
   /* Monotone Palette - Dark Mode */
-  --color-background: #0a0a0a;
-  --color-surface: #1a1a1a;
+  --color-background: #1C1C1C;
+  --color-surface: #2a2a2a;
   --color-text-primary: #f5f5f5;
   --color-text-secondary: #b8b8b8;
   --color-text-muted: #888888;
   --color-border: #333333;
-  --color-accent: #ff3333; /* Slightly brighter red for dark mode */
+  --color-accent: #FFDAB9;
 }
 
 /* Smooth theme transitions */


### PR DESCRIPTION
This commit updates the application's color scheme to a harmonious peach and black palette, as requested.

- Replaced the red accent color with a soft peach (#FFDAB9).
- Adjusted the primary black color to a softer, near-black (#1C1C1C) for better visual harmony.
- Updated the dark theme background and surface colors to complement the new palette.
- The changes have been applied to the global CSS variables, affecting both light and dark themes.