### PR TITLE
feat: Make dark mode default and change red to peach

### DIFF
--- a/public/theme-init.js
+++ b/public/theme-init.js
@@ -2,6 +2,6 @@
 (function() {
   const stored = localStorage.getItem('theme');
   const system = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-  const theme = stored || system;
+  const theme = stored || 'dark';
   document.documentElement.dataset.theme = theme;
 })();

--- a/src/content/blog/css-grid-modernist-layouts.md
+++ b/src/content/blog/css-grid-modernist-layouts.md
@@ -57,7 +57,7 @@ Let's create a layout that would feel at home in a 1920s Bauhaus publication:
 
 .header {
   grid-column: 1 / -1;
-  background: #c13127; /* Bauhaus red */
+  background: var(--color-accent); /* Bauhaus peach */
   color: white;
   padding: var(--grid-8) var(--grid-4);
   text-transform: uppercase;
@@ -102,7 +102,7 @@ Piet Mondrian's geometric compositions translate beautifully to CSS Grid. Here's
 }
 
 .block-red {
-  background: #dc2626;
+  background: var(--color-accent);
   grid-column: 1 / 3;
   grid-row: 1 / 3;
 }
@@ -141,7 +141,7 @@ The Russian constructivists used diagonal lines and dynamic compositions. We can
   transform: rotate(-45deg);
   font-size: clamp(3rem, 8vw, 8rem);
   font-weight: 900;
-  color: #dc2626;
+  color: var(--color-accent);
   text-transform: uppercase;
   display: flex;
   align-items: center;
@@ -254,7 +254,7 @@ Modernist design is all about rhythm and repetition. Here's how to create a rhyt
 .rhythm-grid > :nth-child(4n+1) {
   grid-column: span 3;
   grid-row: span 4;
-  background: #c13127;
+  background: var(--color-accent);
 }
 
 .rhythm-grid > :nth-child(4n+2) {
@@ -297,7 +297,7 @@ One powerful modernist technique is overlapping elements to create depth and vis
 .foreground-block {
   grid-column: 6 / 13;
   grid-row: 3 / 9;
-  background: #dc2626;
+  background: var(--color-accent);
   z-index: 2;
   display: flex;
   align-items: center;
@@ -363,15 +363,15 @@ Even the Bauhaus masters made mistakes. Here's a helpful debugging technique:
   background-image: 
     repeating-linear-gradient(
       0deg,
-      rgba(255, 0, 0, 0.1),
-      rgba(255, 0, 0, 0.1) 1px,
+      rgba(255, 218, 185, 0.1),
+      rgba(255, 218, 185, 0.1) 1px,
       transparent 1px,
       transparent var(--grid-unit)
     ),
     repeating-linear-gradient(
       90deg,
-      rgba(255, 0, 0, 0.1),
-      rgba(255, 0, 0, 0.1) 1px,
+      rgba(255, 218, 185, 0.1),
+      rgba(255, 218, 185, 0.1) 1px,
       transparent 1px,
       transparent var(--grid-unit)
     );

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -283,7 +283,7 @@ const publishedTime = frontmatter.date ? new Date(frontmatter.date).toISOString(
     color: #ffd700 !important;
   }
 
-  /* CSS properties and functions - use red */
+  /* CSS properties and functions - use accent color */
   .post-content :global(.token.property),
   .post-content :global(.token.class-name),
   .post-content :global(.token.function) {


### PR DESCRIPTION
This commit makes two visual changes to the theme:

1.  Dark mode is now the default theme. If a user has not explicitly set a theme, they will be shown the dark version of the site.
2.  All instances of red have been changed to the peach accent color. This includes hardcoded colors in blog posts and updates to comments that referred to the color red.